### PR TITLE
fix(firedac): guard nil FDataSet.Transaction in TDriverDataSetFireDAC.Open monitor-log

### DIFF
--- a/Source/Drivers/DataEngine.DriverFireDac.pas
+++ b/Source/Drivers/DataEngine.DriverFireDac.pas
@@ -571,12 +571,22 @@ end;
 procedure TDriverDataSetFireDAC.Open;
 var
   LParams: TParams;
+  LTxnName: string;
 begin
+  LParams := nil;
   try
     inherited Open;
     LParams := FDataSet.AsParams;
   finally
-    _SetMonitorLog(FDataSet.SQL.Text, FDataSet.Transaction.Name, LParams);
+    // An autonomous read (no active shared transaction) leaves FDataSet.Transaction
+    // nil — FireDAC self-manages the statement. Guard the monitor-log against the nil
+    // deref (FDataSet.Transaction.Name => "Read of address 00000008"); mirrors the
+    // same nil-transaction guard already used in _InternalExecuteQuery.
+    if Assigned(FDataSet.Transaction) then
+      LTxnName := FDataSet.Transaction.Name
+    else
+      LTxnName := '(no transaction)';
+    _SetMonitorLog(FDataSet.SQL.Text, LTxnName, LParams);
     if Assigned(LParams) then
     begin
       LParams.Clear;


### PR DESCRIPTION
## What
`TDriverDataSetFireDAC.Open` (`Source/Drivers/DataEngine.DriverFireDac.pas`) logs the monitor line in its `finally` as `_SetMonitorLog(FDataSet.SQL.Text, FDataSet.Transaction.Name, LParams)`. On an **autonomous read** — `CreateDataSet(sql)` followed by an explicit `IDBDataSet.Open` with no *active* shared transaction — `_InternalExecuteQuery` does not assign `LDataSet.Transaction` (it only does so when the shared txn is `.Active`), so `FDataSet.Transaction` is **nil** and FireDAC self-manages the statement. `FDataSet.Transaction.Name` then dereferences nil → `Access violation ... Read of address 00000008` (offset 8 = `TComponent.FName`).

## Fix
Nil-guard the transaction name in `Open` (emit `'(no transaction)'` when nil) — mirrors the identical nil-transaction guard already present in `_InternalExecuteQuery`. Also `LParams := nil` up front so the `finally` is safe if `inherited Open` raises. No transaction semantics change; read-only safe.

## Why it surfaced
The Janus container read path iterates the already-open dataset and never calls `IDBDataSet.Open`, so it never hit this. A direct `CreateDataSet`+`Open` caller (an aggregate report query) did.

🤖 Generated with [Claude Code](https://claude.com/claude-code)